### PR TITLE
Initialize glad before glViewport (fixes #136)

### DIFF
--- a/src/example3.cpp
+++ b/src/example3.cpp
@@ -78,16 +78,16 @@ int main(int /* argc */, char ** /* argv */) {
         return -1;
     }
     glfwMakeContextCurrent(window);
+    
+    // Create a nanogui screen and pass the glfw pointer to initialize
+    screen = new Screen();
+    screen->initialize(window, true);
 
     int width, height;
     glfwGetFramebufferSize(window, &width, &height);
     glViewport(0, 0, width, height);
     glfwSwapInterval(0);
     glfwSwapBuffers(window);
-
-    // Create a nanogui screen and pass the glfw pointer to initialize
-    screen = new Screen();
-    screen->initialize(window, true);
 
     // Create nanogui gui
     bool enabled = true;


### PR DESCRIPTION
When NANOGUI_GLAD is defined, example3 will crash unless:
1. gladLoadGLLoader((GLADloadproc) glfwGetProcAddress) is called before any other OpenGL calls
2. nanogui::Screen constructor finishes before any other OpenGL calls
